### PR TITLE
Better error message when the image hasn't been signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Container Signing, Verification and Storage in an OCI registry.
 
 ## Installation
 
-For now, clone and `go build ./cmd`.
+For now, clone and `go build -o cosign ./cmd`.
 I'll publish releases when I'm comfortable supporting this for others to use.
 
 ## Usage

--- a/pkg/fetch.go
+++ b/pkg/fetch.go
@@ -19,12 +19,14 @@ package pkg
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
@@ -44,6 +46,9 @@ func FetchSignatures(ref name.Reference) ([]SignedPayload, *v1.Descriptor, error
 
 	rdesc, err := remote.Get(idxRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
+		if te, ok := err.(*transport.Error); ok && te.StatusCode == http.StatusNotFound {
+			return nil, nil, fmt.Errorf("manifest not found: %s", idxRef)
+		}
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
Before

```
$ cosign verify -key=cosign.pub ubuntu
error: GET https://index.docker.io/v2/library/ubuntu/manifests/sha256-703218c0465075f4425e58fac086e09e1de5c340b12976ab9eb8ad26615c3715: MANIFEST_UNKNOWN: manifest unknown; map[Tag:sha256-703218c0465075f4425e58fac086e09e1de5c340b12976ab9eb8ad26615c3715]
```

After

```
$ go run ./cmd verify -key cosign.pub ubuntu
error: manifest not found: index.docker.io/library/ubuntu:sha256-703218c0465075f4425e58fac086e09e1de5c340b12976ab9eb8ad26615c3715
exit status 1
```

It might be even better to say something like, "Is the image signed?" but this is a minor improvement at least.