### PR TITLE
Switch back to only supporting legacy signature formats.

### DIFF
--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -65,7 +65,6 @@ func Sign() *ffcli.Command {
 		upload      = flagset.Bool("upload", true, "whether to upload the signature")
 		payloadPath = flagset.String("payload", "", "path to a payload file to use rather than generating one.")
 		annotations = annotationsMap{}
-		format      = flagset.String("format", "compat", "index|compat")
 	)
 	flagset.Var(&annotations, "a", "extra key=value pairs to sign")
 	return &ffcli.Command{
@@ -80,18 +79,14 @@ func Sign() *ffcli.Command {
 			if len(args) != 1 {
 				return flag.ErrHelp
 			}
-			uploader, ok := pkg.Uploaders[*format]
-			if !ok {
-				return fmt.Errorf("unsupported format flag: %s", *format)
-			}
-			return sign(ctx, *key, args[0], *upload, *payloadPath, annotations.annotations, uploader)
+			return sign(ctx, *key, args[0], *upload, *payloadPath, annotations.annotations)
 		},
 	}
 }
 
 func sign(ctx context.Context, keyPath string,
 	imageRef string, upload bool, payloadPath string,
-	annotations map[string]string, uploader pkg.Uploader) error {
+	annotations map[string]string) error {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return err
@@ -134,5 +129,5 @@ func sign(ctx context.Context, keyPath string,
 	dstTag := ref.Context().Tag(munged)
 
 	fmt.Fprintln(os.Stderr, "Pushing signature to:", dstTag.String())
-	return uploader.Upload(signature, payload, dstTag)
+	return pkg.Upload(signature, payload, dstTag)
 }

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -37,7 +36,6 @@ func Upload() *ffcli.Command {
 	var (
 		flagset   = flag.NewFlagSet("cosign upload", flag.ExitOnError)
 		signature = flagset.String("signature", "", "path to the signature or {-} for stdin")
-		format    = flagset.String("format", "compat", "index|compat")
 	)
 	return &ffcli.Command{
 		Name:       "upload",
@@ -48,16 +46,13 @@ func Upload() *ffcli.Command {
 			if len(args) != 1 {
 				return flag.ErrHelp
 			}
-			uploader, ok := pkg.Uploaders[*format]
-			if !ok {
-				return fmt.Errorf("unsupported format flag: %s", *format)
-			}
-			return upload(ctx, *signature, args[0], uploader)
+
+			return upload(ctx, *signature, args[0])
 		},
 	}
 }
 
-func upload(ctx context.Context, sigRef, imageRef string, uploader pkg.Uploader) error {
+func upload(ctx context.Context, sigRef, imageRef string) error {
 	var b64SigBytes []byte
 	var err error
 
@@ -99,5 +94,5 @@ func upload(ctx context.Context, sigRef, imageRef string, uploader pkg.Uploader)
 	if err != nil {
 		return err
 	}
-	return uploader.Upload(sigBytes, payload, dstTag)
+	return pkg.Upload(sigBytes, payload, dstTag)
 }

--- a/pkg/fetch.go
+++ b/pkg/fetch.go
@@ -52,15 +52,10 @@ func FetchSignatures(ref name.Reference) ([]SignedPayload, *v1.Descriptor, error
 		return nil, nil, err
 	}
 
-	var descriptors []v1.Descriptor
-	switch rdesc.MediaType {
-	case types.DockerManifestSchema2:
-		descriptors, err = Compat.Descriptors(idxRef)
-	case types.OCIImageIndex:
-		descriptors, err = Index.Descriptors(idxRef)
-	default:
-		err = fmt.Errorf("unsupported media type: %s", rdesc.MediaType)
+	if rdesc.MediaType != types.DockerManifestSchema2 {
+		return nil, nil, fmt.Errorf("unsupported media type: %s", rdesc.MediaType)
 	}
+	descriptors, err := Descriptors(idxRef)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
We shouldn't try to be too fancy here, it's best to stick with one
until more registries support the index format.